### PR TITLE
bin v4 (finally refactored): split modules, documentation, tests, CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,32 @@
+name: doc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: leafo/gh-actions-lua@v8.0.0
+      with:
+        luaVersion: "5.3.5"
+
+    - uses: leafo/gh-actions-luarocks@v4.0.0
+
+    - name: install dependencies
+      run: |
+        luarocks install ldoc
+
+    - name: build documentation
+      run: |
+        ldoc .
+
+    - name: publish documentation
+      uses: JamesIves/github-pages-deploy-action@4.1.3
+      with:
+        branch: gh-pages
+        folder: doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  linter:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@master
+      - uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: luajit-openresty
+
+      - uses: leafo/gh-actions-luarocks@v4.0.0
+      - name: install and run luacheck
+        run: |
+          luarocks install luacheck && luacheck .
+
+  test:
+    strategy:
+      matrix:
+        luaVersion: ["luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty"]
+        machineTag: ["ubuntu-latest", "macos-latest"]
+
+    runs-on: ${{ matrix.machineTag }}
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: leafo/gh-actions-lua@v8.0.0
+      with:
+        luaVersion: ${{ matrix.luaVersion }}
+
+    - uses: leafo/gh-actions-luarocks@v4.0.0
+
+    - name: build and fetch dependencies
+      run: |
+        luarocks --server https://moonlibs.github.io/rocks/ make rockspecs/bin-scm-4.rockspec
+
+    - name: test-scribe
+      run: |
+        lua test/scribe.lua
+
+    - name: test-reb
+      run: |
+        lua test/t.lua

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,4 @@
+std = "luajit"
+include_files = { "bin/", "bin.lua" }
+codes = true
+ignore = { "631" --[[ line is too long ]] }

--- a/bin-dev-1.rockspec
+++ b/bin-dev-1.rockspec
@@ -29,7 +29,7 @@ build = {
         ["bin.fixbuf"] = "bin/fixbuf.lua",
         ["bin.rbuf"] = "bin/rbuf.lua",
         ["bin.saferbuf"] = "bin/saferbuf.lua",
-        ['libluabin-scm-3'] = {
+        ['libluabin-scm-4'] = {
             sources = "libluabin.c"
         },
     },

--- a/bin/base.lua
+++ b/bin/base.lua
@@ -1,3 +1,7 @@
+---
+-- This module contains basic binary functions.
+-- @release v4
+-- @module bin.base
 local M = { V = 4 }
 
 local ffi = require 'ffi.reloadable'
@@ -32,22 +36,68 @@ ffi.fundef('bin_xd',[[
 	char * bin_xd(const char *data, size_t size, xd_conf *cf);
 ]])
 
--- endian
-ffi.fundef('bin_htobe16',[[uint16_t bin_htobe16 (uint16_t x);]]) function M.htobe16(x) return lib.bin_htobe16(x) end
-ffi.fundef('bin_htole16',[[uint16_t bin_htole16 (uint16_t x);]]) function M.htole16(x) return lib.bin_htole16(x) end
-ffi.fundef('bin_be16toh',[[uint16_t bin_be16toh (uint16_t x);]]) function M.be16toh(x) return lib.bin_be16toh(x) end
-ffi.fundef('bin_le16toh',[[uint16_t bin_le16toh (uint16_t x);]]) function M.le16toh(x) return lib.bin_le16toh(x) end
-ffi.fundef('bin_htobe32',[[uint32_t bin_htobe32 (uint32_t x);]]) function M.htobe32(x) return lib.bin_htobe32(x) end
-ffi.fundef('bin_htole32',[[uint32_t bin_htole32 (uint32_t x);]]) function M.htole32(x) return lib.bin_htole32(x) end
-ffi.fundef('bin_be32toh',[[uint32_t bin_be32toh (uint32_t x);]]) function M.be32toh(x) return lib.bin_be32toh(x) end
-ffi.fundef('bin_le32toh',[[uint32_t bin_le32toh (uint32_t x);]]) function M.le32toh(x) return lib.bin_le32toh(x) end
-ffi.fundef('bin_htobe64',[[uint64_t bin_htobe64 (uint64_t x);]]) function M.htobe64(x) return lib.bin_htobe64(x) end
-ffi.fundef('bin_htole64',[[uint64_t bin_htole64 (uint64_t x);]]) function M.htole64(x) return lib.bin_htole64(x) end
-ffi.fundef('bin_be64toh',[[uint64_t bin_be64toh (uint64_t x);]]) function M.be64toh(x) return lib.bin_be64toh(x) end
-ffi.fundef('bin_le64toh',[[uint64_t bin_le64toh (uint64_t x);]]) function M.le64toh(x) return lib.bin_le64toh(x) end
---endian
+ffi.fundef('bin_htobe16',[[uint16_t bin_htobe16 (uint16_t x);]])
+---
+-- Converts host byte order to big endian 16 bits.
+-- @param x number
+function M.htobe16(x) return lib.bin_htobe16(x) end
+ffi.fundef('bin_htole16',[[uint16_t bin_htole16 (uint16_t x);]])
+---
+-- Converts host byte order to little endian 16 bits.
+-- @param x number
+function M.htole16(x) return lib.bin_htole16(x) end
+ffi.fundef('bin_be16toh',[[uint16_t bin_be16toh (uint16_t x);]])
+---
+-- Converts big endian 16 bits to host byte order.
+-- @param x number
+function M.be16toh(x) return lib.bin_be16toh(x) end
+ffi.fundef('bin_le16toh',[[uint16_t bin_le16toh (uint16_t x);]])
+---
+-- Converts little endian 16 bits to host byte
+-- @param x number
+function M.le16toh(x) return lib.bin_le16toh(x) end
+ffi.fundef('bin_htobe32',[[uint32_t bin_htobe32 (uint32_t x);]])
+---
+-- Converts host byte order to big endian 32 bits.
+-- @param x number
+function M.htobe32(x) return lib.bin_htobe32(x) end
+ffi.fundef('bin_htole32',[[uint32_t bin_htole32 (uint32_t x);]])
+---
+-- Converts host byte order to little endian 32 bits.
+-- @param x number
+function M.htole32(x) return lib.bin_htole32(x) end
+ffi.fundef('bin_be32toh',[[uint32_t bin_be32toh (uint32_t x);]])
+---
+-- Converts big endian 32 bits to host byte order.
+-- @param x number
+function M.be32toh(x) return lib.bin_be32toh(x) end
+ffi.fundef('bin_le32toh',[[uint32_t bin_le32toh (uint32_t x);]])
+---
+-- Converts little endian 32 bits to host byte
+-- @param x number
+function M.le32toh(x) return lib.bin_le32toh(x) end
+ffi.fundef('bin_htobe64',[[uint64_t bin_htobe64 (uint64_t x);]])
+---
+-- Converts host byte order to big endian 64 bits.
+-- @param x number
+function M.htobe64(x) return lib.bin_htobe64(x) end
+ffi.fundef('bin_htole64',[[uint64_t bin_htole64 (uint64_t x);]])
+---
+-- Converts host byte order to little endian 64 bits.
+-- @param x number
+function M.htole64(x) return lib.bin_htole64(x) end
+ffi.fundef('bin_be64toh',[[uint64_t bin_be64toh (uint64_t x);]])
+---
+-- Converts big endian 64 bits to host byte order.
+-- @param x number
+function M.be64toh(x) return lib.bin_be64toh(x) end
+ffi.fundef('bin_le64toh',[[uint64_t bin_le64toh (uint64_t x);]])
+---
+-- Converts little endian 64 bits to host byte
+-- @param x number
+function M.le64toh(x) return lib.bin_le64toh(x) end
 
-M.jit_major = jit.version:match("LuaJIT (%d%.%d)")
+M.jit_major = require 'jit'.version_num
 
 if not rawget(_G, 'dostring') then
 	if not rawget(_G, 'loadstring') then
@@ -57,6 +107,14 @@ if not rawget(_G, 'dostring') then
 	rawset(_G, 'dostring', function(str) return assert(loadstring(str))() end)
 end
 
+---
+-- Returns hex representation of the binary data
+-- @param data accepts string, allmost any pointer - start of the data.
+-- @param len length of the data in bytes
+-- @treturn string `hex` representation of the data
+-- @usage
+-- print(bin.hex "some binary string")
+-- 736F6D652062696E61727920737472696E67
 function M.hex(data, len)
 	len = len or #data
 	local buf = lib.bin_hex(ffi.cast("char*",data),len);
@@ -70,6 +128,15 @@ function M.hex(data, len)
 	return rv
 end
 
+---
+-- Returns hexdump (hexdump -C) of the binary data
+-- @param data accepts string, allmost any pointer - start of the data.
+-- @param len length of the data in bytes
+-- @treturn string `hexdump` representation of the data
+-- @usage
+-- print(bin.xd "some binary string")
+-- [0000]   73 6F 6D 65  20 62 69 6E  61 72 79 20  73 74 72 69   some  bin ary  stri
+-- [0010]   6E 67                                                ng
 function M.xd(data, len)
 	len = len or #data
 	local buf = lib.bin_xd(ffi.cast("char*",data),len,nil);

--- a/bin/rbuf.lua
+++ b/bin/rbuf.lua
@@ -1,3 +1,32 @@
+---
+-- Implements unsafe binary Reader.
+--
+-- Same as `bin.basebuf` supports decoding numbers
+-- into any endianess.
+--
+-- `{u,i}{8,16,32,64}{be,le,}` are supported opposite to defined at @{bin.basebuf}.
+-- @module bin.rbuf
+
+---
+-- Implements unsafe binary Reader.
+-- Has following structure.
+--
+--	struct bin_rbuf {
+--	 	const char * buf;
+--	 	union {
+--	 		const char     *c;
+--	 		const int8_t   *i8;
+--	 		const uint8_t  *u8;
+--	 		const int16_t  *i16;
+--	 		const uint16_t *u16;
+--	 		const int32_t  *i32;
+--	 		const uint32_t *u32;
+--	 		const int64_t  *i64;
+--	 		const uint64_t *u64;
+--	 	} p;
+--	 	size_t len;
+--	};
+-- @type rbuf
 local rbuf = {}
 local ffi = require 'ffi.reloadable'
 local C = ffi.C
@@ -78,8 +107,11 @@ function rbuf:reb()
 	end
 end
 
--- BER isn't supported for lower version of LuaJIT
-if require 'jit'.version_num >= 20100 then
+---
+-- Decodes VLQ number Opposite to @{bin.basebuf.ber} (LuaJIT >= 2.1).
+-- @function rbuf:ber
+-- @return `number` decoded value
+if base.jit_major >= 20100 then
 	function rbuf:ber()
 		local n = 0ULL
 		for i = 0,8 do
@@ -93,33 +125,64 @@ if require 'jit'.version_num >= 20100 then
 	end
 end
 
+---
+-- [unsafe] Extracts `len` bytes from buffer as `string`
+-- @number len size of resulting string
+-- @return `string` str
 function rbuf:str(len)
 	local str = ffi.string( self.p.c, len )
 	self.p.c = self.p.c + len
 	return str
 end
+
+---
+-- [safe] Returns nice hexdump of the remaining buffer
+-- @see bin.base.xd
+-- @return `string` hexdump
 function rbuf:dump()
 	return base.xd(self.p.c,self.len - (self.p.c-self.buf),nil)
 end
 
+---
+-- [safe] Returns hex representation of the remaining buffer
+-- @see bin.base.hex
+-- @return `string` hex
 function rbuf:hex()
 	return base.hex(self.p.c,self.len - (self.p.c-self.buf))
 end
 
+---
+-- [safe] memmoves remaining buffer to the beginning.
+-- shrinks `len` of the buffer.
 function rbuf:move()
-	C.memmove( self.buf, self.p.c, self.len - (self.p.c-self.buf) )
+	local size = self.len - (self.p.c - self.buf)
+	C.memmove(self.buf, self.p.c, size)
 	self.p.c = self.buf
+	self.len = size
 end
 
+---
+-- [unsafe] Forwards cursor for `len` bytes (accepts negatives).
+-- @number `len`
 function rbuf:skip(len)
 	self.p.c = self.p.c + len
 end
 
+---
+-- [safe] Returns remaining part of the buffer
+-- @return `left` bytes
 function rbuf:avail()
 	return self.len - (self.p.c-self.buf)
 end
 
-local M = {}
+local M = { buf = rbuf }
+
+---
+-- Creates rbuf from pointer
+-- @constructor
+-- @tparam char* p pointer or string
+-- @param[opt=#p] l length of the pointer
+-- @return `rbuf`
 function M.new(p, l)
 	if not l then l = #p end
 	local self = rbuf_t{ buf = p; len = l; }

--- a/bin/saferbuf.lua
+++ b/bin/saferbuf.lua
@@ -1,8 +1,51 @@
+---
+-- Implements Safe binary Reader.
+--
+-- Example of usage [ochaton/migrate](https://github.com/ochaton/migrate/blob/29663cf96b0103963a1f78dbbbc91df9bf1fec98/migrate/init.lua#L31)
+--
+-- Same as @{bin.rbuf} but safer.
+-- Always checks bounds of the buffer.
+-- @see bin.rbuf.dump
+-- @see bin.rbuf.hex
+-- @see bin.rbuf.move
+-- @see bin.rbuf.avail
+-- @module bin.saferbuf
+
+---
+-- Safe rbuf implements everything `bin.rbuf` does but adds bounds checks.
+-- Has following structure.
+--
+--	struct bin_safe_rbuf {
+--	 	const char * buf;
+--	 	union {
+--	 		const char     *c;
+--	 		const int8_t   *i8;
+--	 		const uint8_t  *u8;
+--	 		const int16_t  *i16;
+--	 		const uint16_t *u16;
+--	 		const int32_t  *i32;
+--	 		const uint32_t *u32;
+--	 		const int64_t  *i64;
+--	 		const uint64_t *u64;
+--	 	} p;
+--	 	size_t len;
+--	};
+-- @see bin.rbuf.dump
+-- @see bin.rbuf.hex
+-- @see bin.rbuf.move
+-- @see bin.rbuf.avail
+-- @type saferbuf
 local srbuf = {}
 local ffi = require 'ffi.reloadable'
 local C = ffi.C
 
 local base = require 'bin.base'
+local rbuf = require 'bin.rbuf'.buf
+
+srbuf.dump  = rbuf.dump
+srbuf.hex   = rbuf.hex
+srbuf.move  = rbuf.move
+srbuf.avail = rbuf.avail
 
 local function bin_safe_rbuf_str(self)
 	return string.format(
@@ -87,8 +130,12 @@ function srbuf:reb()
 	end
 end
 
--- BER isn't supported for lower version of LuaJIT
-if base.jit_major >= "2.1" then
+
+---
+-- Decodes VLQ number Opposite to @{bin.basebuf.ber} (LuaJIT >= 2.1).
+-- @function srbuf:ber
+-- @return `number` decoded value
+if base.jit_major >= 20100 then
 	function srbuf:ber()
 		local n = 0ULL
 		for i = 0,8 do
@@ -103,44 +150,47 @@ if base.jit_major >= "2.1" then
 	end
 end
 
+---
+-- Reads `len` bytes from buffer and returns `string`.
+-- @number len
+-- @return string
 function srbuf:str(len)
 	self:have(len, 3)
 	local str = ffi.string(self.p.c, len)
 	self.p.c = self.p.c + len
 	return str
 end
-function srbuf:dump()
-	return base.xd(self.p.c,self.len - (self.p.c-self.buf),nil)
-end
 
-function srbuf:hex()
-	return base.hex(self.p.c,self.len - (self.p.c-self.buf))
-end
-
-function srbuf:move()
-	C.memmove( self.buf, self.p.c, self.len - (self.p.c-self.buf) )
-	self.p.c = self.buf
-end
-
+---
+-- Forwards cursor for `len` bytes (bounds checks inside)
+-- @number len number of bytes
 function srbuf:skip(len)
 	self:have(len, 3)
 	self.p.c = self.p.c + len
 end
 
+---
+-- Checks that buffer has at least `bytes` till the end
+-- @number[opt=0] bytes
+-- @number[opt=2] lvl
+-- @treturn number bytes to the end of the buffer
 function srbuf:have(bytes, lvl)
-	if not bytes then return self:avail() end
+	local avail = self:avail()
+	bytes = bytes or 0
 	if bytes > self:avail() then
 		lvl = lvl or 2
 		error("not enough bytes", lvl)
 	end
-	return true
-end
-
-function srbuf:avail()
-	return self.len - (self.p.c-self.buf)
+	return avail
 end
 
 local M = {}
+---
+-- Creates reader from given pointer
+-- @constructor
+-- @tparam `char *` ptr string or pointer
+-- @number[opt=#str] size of the buffer
+-- @return `saferbuf`
 function M.new(p, l)
 	if not l then l = #p end
 	local self = saferbuf_t{ buf = p; len = l; }

--- a/config.ld
+++ b/config.ld
@@ -1,0 +1,19 @@
+project = 'Bin'
+title = 'Bin'
+description = "Eases work with binary data in LuaJIT"
+full_description = [[
+	Module bin provides many functions to perfom binary transformations.
+
+	bin implements 2 write buffers (bin.buf and bin.fixbuf)
+	to ease construct binary data.
+
+	Also bin implements 2 read buffer (bin.saferbuf and bin.rbuf)
+	to ease organize parsing of binary data.
+]]
+file = {'bin'}
+readme = 'README.md'
+format = 'discount'
+style = "!pale"
+wrap = true
+not_luadoc = true
+no_space_before_args = true

--- a/test/sample.lua
+++ b/test/sample.lua
@@ -17,6 +17,8 @@ local function dump(x)
 	return j.encode(x)
 end
 
+package.path = "./?.lua;"..package.path
+print(package.searchpath('bin', package.path))
 
 local bin = require 'bin'
 

--- a/test/scribe.lua
+++ b/test/scribe.lua
@@ -1,3 +1,6 @@
+package.path = "./?.lua;"..package.path
+print(package.searchpath('bin', package.path))
+
 local bin = require 'bin'
 local ffi = require 'ffi'
 
@@ -121,7 +124,7 @@ function send(...)
 		sz = sz+1
 	end
 	sz = sz+1
-	
+
 	local buf = bin.fixbuf(sz)
 	local hdr = ffi.cast( 'sc_hdr_t *', buf:alloc(HDR_SZ) )
 	ffi.copy(hdr,def_hdr,HDR_SZ)

--- a/test/t.lua
+++ b/test/t.lua
@@ -1,11 +1,13 @@
 --[[
 You can run this tests using typing this in the shell:
 # LuaJIT (tested on 2.0.5)
-LUA_CPATH="./?.so" LUA_PATH="./?.lua;/home/ochaton/.luarocks/share/lua/5.1/?.lua" luajit t.lua
-	# Tarantool (tested on 1.10.2-26-gb2ddd18)
-LUA_CPATH="./?.so" LUA_PATH="./?.lua;/home/ochaton/.luarocks/share/lua/5.1/?.lua" tarantool t.lua
+luajit test/t.lua
+
+# Tarantool (tested on 1.10.2-26-gb2ddd18)
+tarantool test/t.lua
 ]]
 
+package.path = "./?.lua;"..package.path
 print(package.searchpath('bin', package.path))
 -- TODO: import tap based tests
 local bin = require 'bin'


### PR DESCRIPTION
Finally, moonlibs has some kind of automatisation!

This huge patch fully compatible with bin/scm-3 (except that some bugs were fixed).

Alpha version of bin/scm-4 has been deployed to core systems of cloud@mail.ru 5 moths ago. No bugs were reported since.

Mainly, this patch aimed to:
1. Split implementation of 4 buffer classes into separate files
2. Implement bin.saferbuf as basic class to do unmarshalling binary data in LuaJIT
3. Perform full compatibility with luajit/openresty, luajit-2.0.5, luajit-2.0.4 (not only Tarantool)
4. Write first version of documentation with some examples.